### PR TITLE
fix setup requirements using setuptools (fix #6)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=["buildbot_slack"],
-    requires=["buildbot (>=2.0.0)", "treq (>=18.6)"],
+    install_requires=["buildbot (>=2.0.0)", "treq (>=18.6)"],
     entry_points={
         "buildbot.reporters": [
             "SlackStatusPush = buildbot_slack.reporter:SlackStatusPush"


### PR DESCRIPTION
mismatch between distutils recommendation around setup.py ("requires" - https://docs.python.org/3/distutils/setupscript.html#relationships-between-distributions-and-packages) and setuptools