### PR TITLE
Fix import string in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Create a new incoming webhook in your slack account. (see https://api.slack.com/
 Then in your master.cfg, add the following:
 
 ```
-from buildbot import reporters
+from buildbot.plugins import reporters
 c['services'].append(reporters.SlackStatusPush(
     endpoint=<YOUR_WEBHOOK_ENDPOINT>,
 ))


### PR DESCRIPTION
This README indicates users are supposed to import this plugin from `buildbot.reporters`:

```python
from buildbot import reporters
```

but there is [no plugin registration or import mechanism in `buildbot.reporters`](https://github.com/buildbot/buildbot/blob/master/master/buildbot/reporters/__init__.py), and the buildbot documentation [imports third party plugins from `buildbot.plugins`](https://docs.buildbot.net/latest/manual/configuration/reporters.html#httpstatuspush):

```python
from buildbot.plugins import reporters
```

Importing from `buildbot.plugins.reporters` solved this problem for me, and would probably fix #3 as well.