### PR TITLE
Fix typo in reports: "Commiters" -> "Committers"

### DIFF
--- a/buildbot_slack/reporter.py
+++ b/buildbot_slack/reporter.py
@@ -139,7 +139,7 @@ class SlackStatusPush(http.HttpStatusPushBase):
                 if responsible_users:
                     fields.append(
                         {
-                            "title": "Commiters",
+                            "title": "Committers",
                             "value": ", ".join(responsible_users),
                             "short": True,
                         }


### PR DESCRIPTION
Not sure this is worth a PR, but there you go...
Thanks for this cool plugin BTW !