### PR TITLE
Draft: Update to support Buildbot 3+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dist/
 *.egg-info/
 build/
+.idea


### PR DESCRIPTION
Due to #13, this project no longer works with current version of buildbot. This PR includes a working version of this project that has been updated to address this issue - tested on buildbot 3.0.2.

However, I also changed some other stuff to get this working for the project I was working on, so it should be cleaned up and tested thoroughly before a merge. I don't have time to do that, but figured I would at least share it here in case it's helpful to anyone else. Anyone is welcome to take over this PR if they'd like.

Also, here's an example of a report (one of the objects in the `reports` list passed to `sendMessage`) for reference:

```
"""
{'body': 'Build done.',
 'subject': None,
 'type': 'plain',
 'builder_name': 'builder_fast_tests',
 'results': 0,
 'builds': [{'buildid': 1,
   'number': 1,
   'builderid': 2,
   'buildrequestid': 1,
   'workerid': 3,
   'masterid': 1,
   'started_at': datetime.datetime(2021, 9, 12, 2, 43, 54, tzinfo=tzutc()),
   'complete_at': datetime.datetime(2021, 9, 12, 2, 44, 19, tzinfo=tzutc()),
   'complete': True,
   'state_string': 'build successful',
   'results': 0,
   'properties': {'reason': ('force build', 'Force Build Form'),
    'owner': ('xxx@gmail.com', 'Force Build Form'),
    'scheduler': ('force', 'Scheduler'),
    'buildername': ('builder_fast_tests', 'Builder'),
    'workername': ('worker_fast_tests', 'Worker'),
    'buildnumber': (1, 'Build'),
    'branch': ('xxx/build_on_pr', 'Build'),
    'revision': ('', 'Build'),
    'repository': ('', 'Build'),
    'codebase': ('', 'Build'),
    'project': ('', 'Build'),
    'owners': (['xxx@gmail.com'], 'Build'),
    'builddir': ('/opt/buildbot/worker_fast_tests/builder_fast_tests',
     'Worker'),
    'got_revision': ('c62xxxxxxxxxxxxxc18', 'GitLab')},
   'buildrequest': {'buildrequestid': 1,
    'buildsetid': 1,
    'builderid': 2,
    'priority': 0,
    'claimed': True,
    'claimed_at': datetime.datetime(2021, 9, 12, 2, 43, 54, tzinfo=tzutc()),
    'claimed_by_masterid': 1,
    'complete': True,
    'results': 0,
    'submitted_at': datetime.datetime(2021, 9, 12, 2, 43, 54, tzinfo=tzutc()),
    'complete_at': datetime.datetime(2021, 9, 12, 2, 44, 19, tzinfo=tzutc()),
    'waited_for': False,
    'properties': None},
   'buildset': {'external_idstring': None,
    'reason': "A build was forced by 'xxx@gmail.com': force build",
    'submitted_at': 1631414634,
    'complete': True,
    'complete_at': 1631414659,
    'results': 0,
    'bsid': 1,
    'sourcestamps': [{'ssid': 1,
      'branch': 'xxx/build_on_pr',
      'revision': '',
      'project': '',
      'repository': '',
      'codebase': '',
      'created_at': datetime.datetime(2021, 9, 12, 2, 43, 54, tzinfo=tzutc()),
      'patch': None}],
    'parent_buildid': None,
    'parent_relationship': None},
   'parentbuild': None,
   'parentbuilder': None,
   'builder': {'builderid': 2,
    'name': 'builder_fast_tests',
    'masterids': [1],
    'description': None,
    'tags': []},
   'url': 'http://localhost:8081/#builders/2/builds/1'}],
 'users': ['xxx@gmail.com'],
 'patches': [],
 'logs': []}
```